### PR TITLE
adjust the logic regarding shared or exclusive locks to the DB file

### DIFF
--- a/src/db/db.rs
+++ b/src/db/db.rs
@@ -89,7 +89,7 @@ impl<'a> DB {
 		let needs_initialization = (!std::path::Path::new(path.as_ref().unwrap()).exists())
 			|| file.metadata().map_err(|_| "Can't read metadata")?.len() == 0;
 
-		if options.read_only {
+		if !options.read_only {
 			file.lock_exclusive().map_err(|_e| "Cannot lock db file")?;
 		} else {
 			file.lock_shared().map_err(|_e| "Cannot lock db file")?;


### PR DESCRIPTION
i started digging into this because on a Windows machine i would get errors saying can't write a buffer because the file is locked by another process.