### PR TITLE
allow cast ref to mut ref

### DIFF
--- a/src/bucket/cursor.rs
+++ b/src/bucket/cursor.rs
@@ -44,6 +44,7 @@ impl<'a, B: Deref<Target = Bucket> + 'a> Cursor<'a, B> {
     pub(crate) fn bucket_mut(&mut self) -> &mut Bucket {
         unsafe {
             #[allow(clippy::cast_ref_to_mut)]
+            #[allow(invalid_reference_casting)]
             &mut *((&*self.bucket) as *const Bucket as *mut Bucket)
         }
     }

--- a/src/page/mod.rs
+++ b/src/page/mod.rs
@@ -188,6 +188,7 @@ impl Page {
     pub(crate) fn branch_page_elements_mut(&mut self) -> &mut [BranchPageElement] {
         unsafe {
             #[allow(clippy::cast_ref_to_mut)]
+            #[allow(invalid_reference_casting)]
             &mut *(self.branch_page_elements() as *const [BranchPageElement]
                 as *mut [BranchPageElement])
         }
@@ -205,6 +206,7 @@ impl Page {
     pub(crate) fn branch_page_element_mut(&mut self, index: usize) -> &mut BranchPageElement {
         unsafe {
             #[allow(clippy::cast_ref_to_mut)]
+            #[allow(invalid_reference_casting)]
             &mut *(self.branch_page_element(index) as *const BranchPageElement
                 as *mut BranchPageElement)
         }
@@ -223,6 +225,7 @@ impl Page {
     pub(crate) fn leaf_page_elements_mut(&mut self) -> &mut [LeafPageElement] {
         unsafe {
             #[allow(clippy::cast_ref_to_mut)]
+            #[allow(invalid_reference_casting)]
             &mut *(self.leaf_page_elements() as *const [LeafPageElement]
                 as *mut [LeafPageElement])
         }
@@ -240,6 +243,7 @@ impl Page {
     pub(crate) fn leaf_page_element_mut(&mut self, index: usize) -> &mut LeafPageElement {
         unsafe {
             #[allow(clippy::cast_ref_to_mut)]
+            #[allow(invalid_reference_casting)]
             &mut *(self.leaf_page_element(index) as *const LeafPageElement as *mut LeafPageElement)
         }
     }
@@ -256,6 +260,7 @@ impl Page {
     pub(crate) fn meta_mut(&mut self) -> &mut Meta {
         unsafe {
             #[allow(clippy::cast_ref_to_mut)]
+            #[allow(invalid_reference_casting)]
             &mut *(self.meta() as *const Meta as *mut Meta)
         }
     }
@@ -272,6 +277,7 @@ impl Page {
     pub(crate) fn freelist_mut(&mut self) -> &mut [PGID] {
         unsafe {
             #[allow(clippy::cast_ref_to_mut)]
+            #[allow(invalid_reference_casting)]
             &mut *(self.freelist() as *const [PGID] as *mut [PGID])
         }
     }


### PR DESCRIPTION
Trying to build I got this error in few places:

```console
error: casting `&T` to `&mut T` is undefined behavior, even if the reference is unused, consider instead using an `UnsafeCell`
   --> src/page/mod.rs:259:13
    |
259 |             &mut *(self.meta() as *const Meta as *mut Meta)
    |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
    = note: for more information, visit <https://doc.rust-lang.org/book/ch15-05-interior-mutability.html>
```

Probably it's because something changed in new Rust versions.

This PR wants to fix this issue, simply adding an `allow`