### PR TITLE
remove option from path

### DIFF
--- a/src/bucket/tests.rs
+++ b/src/bucket/tests.rs
@@ -57,7 +57,7 @@ fn create_nested_buckets() {
             .is_some());
 
         tx.commit().unwrap();
-        db.path().unwrap()
+        db.path().to_owned()
     };
 
     let db = db_mock().path(path).build().unwrap();

--- a/src/tx/tests.rs
+++ b/src/tx/tests.rs
@@ -133,7 +133,7 @@ fn commit_ensure() {
             bucket.put(b"thomas", b"jefferson".to_vec()).unwrap();
         }
         tx.commit().unwrap();
-        db.path().unwrap()
+        db.path().to_owned()
     };
 
     let db = DBBuilder::new(path)


### PR DESCRIPTION
Removing `Option` from database `path` field as it is always needed. Previously was handled with an `unwrap` 